### PR TITLE
Remove date filter from test queries

### DIFF
--- a/pages/test-preparation.php
+++ b/pages/test-preparation.php
@@ -104,7 +104,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             <?php $week = date('Y-m-d', strtotime('-14 days')); ?>
             <?php $realization = "(SELECT 1 FROM test_realization WHERE sample_id= p.sample_id AND sample_number = p.sample_number AND test_type = p.test_type)"; ?>
-            <?php $Seach = find_by_sql("SELECT id, Sample_ID, Sample_Number, Test_Type, Technician, Start_Date FROM test_preparation p WHERE Start_Date >= '{$week}' AND NOT EXISTS $realization ORDER BY Register_Date DESC"); ?>
+            <?php $Seach = find_by_sql("SELECT id, Sample_ID, Sample_Number, Test_Type, Technician, Start_Date FROM test_preparation p WHERE NOT EXISTS $realization ORDER BY Register_Date DESC"); ?>
 
             <form id="multiple-send-form" method="post" action="test-preparation.php">
               <table class="table datatable">

--- a/pages/test-realization.php
+++ b/pages/test-realization.php
@@ -47,7 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             <?php $week = date('Y-m-d', strtotime('-14 days')); ?>
             <?php $realization = "(SELECT 1 FROM test_delivery WHERE sample_id = p.sample_id AND sample_number = p.sample_number AND test_type = p.test_type)"; ?>
-            <?php $Seach = find_by_sql("SELECT id, Sample_ID, Sample_Number, Test_Type, Technician, Start_Date FROM test_realization p WHERE Start_Date >= '{$week}' AND NOT EXISTS $realization ORDER BY Register_Date DESC"); ?>
+            <?php $Seach = find_by_sql("SELECT id, Sample_ID, Sample_Number, Test_Type, Technician, Start_Date FROM test_realization p WHERE NOT EXISTS $realization ORDER BY Register_Date DESC"); ?>
 
             <form id="multiple-send-form" method="post" action="test-realization.php">
               <table class="table datatable">


### PR DESCRIPTION
Eliminated the 'Start_Date >= last 14 days' condition from SQL queries in test-preparation.php and test-realization.php, allowing results to include all records not present in related tables regardless of date.