### PR TITLE
Remove unused variable from SQL insert statement

### DIFF
--- a/database/standard-proctor/save.php
+++ b/database/standard-proctor/save.php
@@ -195,8 +195,7 @@ if (isset($_POST['SaveSP'])) {
             '$Ydt',
             '$YwKnm',
             '$CorrectedDryUnitWeigt',
-            '$CorrectedWaterContentFiner',
-            '$Graph64'";
+            '$CorrectedWaterContentFiner'";
 
         // Add the dynamically generated values to the query
         for ($i = 1; $i <= 6; $i++) {


### PR DESCRIPTION
Eliminated the '$Graph64' variable from the SQL insert values in save.php, as it was not required for the database operation.